### PR TITLE
fix-beta-correlation

### DIFF
--- a/qp_qiime2/__init__.py
+++ b/qp_qiime2/__init__.py
@@ -196,7 +196,7 @@ outputs = {'Beta group significance visualization': 'q2_visualization'}
 dflt_param_set = {
     'Defaults': {
         'Method': 'PERMANOVA',
-        'Comparison type': 'p-pairwise',
+        'Comparison type': 'Pairwise',
         'Number of permutations': 999}
 }
 qiime_cmd = QiitaCommand(

--- a/qp_qiime2/qiime2.py
+++ b/qp_qiime2/qiime2.py
@@ -726,10 +726,10 @@ def filter_samples(qclient, job_id, parameters, out_dir):
 
     qclient.update_job_step(job_id, "Step 3 of 4: Filtering")
     filter_ofp = join(out_dir, 'biom_filtered.qza')
-    if 'Exclude ids selected by where parameter':
-        exclude_ids = '--p-no-exclude-ids'
-    else:
+    if parameters['Exclude ids selected by where parameter']:
         exclude_ids = '--p-exclude-ids'
+    else:
+        exclude_ids = '--p-no-exclude-ids'
     cmd = ('qiime feature-table filter-samples --m-metadata-file %s '
            '--o-filtered-table %s --p-max-frequency %d --p-max-features %d '
            '--p-min-frequency %d --p-min-features %d --i-table %s %s' % (

--- a/qp_qiime2/qiime2.py
+++ b/qp_qiime2/qiime2.py
@@ -393,7 +393,7 @@ def beta_correlation(qclient, job_id, parameters, out_dir):
     qclient.update_job_step(
         job_id, "Step 4 of 4: Calculating beta correlation")
     cmd = ('qiime diversity mantel --i-dm1 %s --i-dm2 %s --p-method %s '
-           '--p-permutations %s --p-no-intersect-ids '
+           '--p-permutations %s --p-intersect-ids '
            '--p-label1 "Distance Matrix" --p-label2 "%s" '
            '--o-visualization %s' % (
               dm_qza, metadata_qza, p_method, p_permutations,


### PR DESCRIPTION
Turns out that I can't read tutorials/help. There is a bug in qiita-rc cause I used the wrong flag. This flags basically removes samples not present in both distance matrices, which is possible if the metadata column is empty or if we lost samples at any given point of the processing.

```
  --p-intersect-ids / --p-no-intersect-ids
                                  If supplied, IDs that are not found in both
                                  distance matrices will be discarded before
                                  applying the Mantel test. Default behavior
                                  is to error on any mismatched IDs.
                                  [default: False]
```