### PR TITLE
etype -> pname

### DIFF
--- a/qp_qiime2/__init__.py
+++ b/qp_qiime2/__init__.py
@@ -160,7 +160,7 @@ for q2plugin, m in methods_to_add:
                 break
             else:
                 etype = Q2_QIITA_SEMANTIC_TYPE[qt_name]
-                outputs_params[etype] = etype
+                outputs_params[pname] = etype
 
     if len(inputs) != 1 or not add_method:
         # As of qiime2-2021.2 this filters out:


### PR DESCRIPTION
There is a type on the name of the outputs that errors all jobs - note that currently there is no way to test this so I'm going to open an issue in Qiita to add how to test. 